### PR TITLE
Ticket 50434 - Jenkins plugin cannot start the Blueprint

### DIFF
--- a/src/main/java/com/quali/cloudshell/service/SandboxAPIRequestInterceptor.java
+++ b/src/main/java/com/quali/cloudshell/service/SandboxAPIRequestInterceptor.java
@@ -17,15 +17,30 @@ public class SandboxAPIRequestInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
 
+        Request newRequest;
         String authToken = sandboxAPISpecProvider.getAuthToken();
 
-        sandboxAPISpecProvider.setAuthToken(authToken);
+        if (chain.request().url().toString().toLowerCase().contains("login"))
+        {
 
-        Request newRequest = chain.request().newBuilder()
-                .addHeader("Content-Type", "application/json")
-                .header("Authorization", "Basic " + authToken)
-                .build();
+            sandboxAPISpecProvider.setAuthToken(authToken);
 
+            newRequest = chain.request().newBuilder()
+                    .addHeader("Content-Type", "application/json")
+                    .header("Authorization", "Basic " + authToken)
+                    .build();
+
+        }
+    
+        else
+        {
+            try{ sandboxAPISpecProvider.loginAndSetAuthToken();}
+            catch (Exception e) {}
+            newRequest = chain.request().newBuilder()
+                    .addHeader("Content-Type", "application/json")
+                    .header("Authorization", "Basic " + sandboxAPISpecProvider.getAuthToken())
+                    .build();
+        }
         return chain.proceed(newRequest);
     }
 }


### PR DESCRIPTION
https://cs18.visualstudio.com/Torque/_boards/board/t/Webos/Stories/?workitem=7239

Some versions of Cloudshell do not return error code 401 as part of response for invalid tokens. Previously we relid on error code 401 in logon, by intercepting requests, trying to logon with purposely invalid token, getting 401 and then handling that by logging on. Since there are production versions of cloudshell without that capability, we now will always logon before each request